### PR TITLE
修正apr在vs2013下编译出现：

### DIFF
--- a/kbe/src/lib/third_party/apr/atomic/win32/apr_atomic.c
+++ b/kbe/src/lib/third_party/apr/atomic/win32/apr_atomic.c
@@ -49,7 +49,7 @@ APR_DECLARE(apr_uint32_t) apr_atomic_add32(volatile apr_uint32_t *mem, apr_uint3
 #elif defined(__MINGW32__)
     return InterlockedExchangeAdd((long *)mem, val);
 #else
-    return ((apr_atomic_win32_ptr_val_fn)InterlockedExchangeAdd)(mem, val);
+	return InterlockedExchangeAdd(mem, val);
 #endif
 }
 
@@ -65,7 +65,7 @@ APR_DECLARE(void) apr_atomic_sub32(volatile apr_uint32_t *mem, apr_uint32_t val)
 #elif defined(__MINGW32__)
     InterlockedExchangeAdd((long *)mem, -val);
 #else
-    ((apr_atomic_win32_ptr_val_fn)InterlockedExchangeAdd)(mem, -val);
+	InterlockedExchangeAdd(mem, -val);
 #endif
 }
 
@@ -77,7 +77,7 @@ APR_DECLARE(apr_uint32_t) apr_atomic_inc32(volatile apr_uint32_t *mem)
 #elif defined(__MINGW32__)
     return InterlockedIncrement((long *)mem) - 1;
 #else
-    return ((apr_atomic_win32_ptr_fn)InterlockedIncrement)(mem) - 1;
+	return InterlockedIncrement(mem) - 1;
 #endif
 }
 
@@ -88,7 +88,7 @@ APR_DECLARE(int) apr_atomic_dec32(volatile apr_uint32_t *mem)
 #elif defined(__MINGW32__)
     return InterlockedDecrement((long *)mem);
 #else
-    return ((apr_atomic_win32_ptr_fn)InterlockedDecrement)(mem);
+	return InterlockedDecrement(mem);
 #endif
 }
 
@@ -99,7 +99,7 @@ APR_DECLARE(void) apr_atomic_set32(volatile apr_uint32_t *mem, apr_uint32_t val)
 #elif defined(__MINGW32__)
     InterlockedExchange((long*)mem, val);
 #else
-    ((apr_atomic_win32_ptr_val_fn)InterlockedExchange)(mem, val);
+	InterlockedExchange(mem, val);
 #endif
 }
 
@@ -116,7 +116,7 @@ APR_DECLARE(apr_uint32_t) apr_atomic_cas32(volatile apr_uint32_t *mem, apr_uint3
 #elif defined(__MINGW32__)
     return InterlockedCompareExchange((long*)mem, with, cmp);
 #else
-    return ((apr_atomic_win32_ptr_val_val_fn)InterlockedCompareExchange)(mem, with, cmp);
+	return InterlockedCompareExchange(mem, with, cmp);
 #endif
 }
 
@@ -128,7 +128,7 @@ APR_DECLARE(void *) apr_atomic_casptr(volatile void **mem, void *with, const voi
     return InterlockedCompareExchangePointer((void**)mem, with, (void*)cmp);
 #else
     /* Too many VC6 users have stale win32 API files, stub this */
-    return ((apr_atomic_win32_ptr_ptr_ptr_fn)InterlockedCompareExchange)(mem, with, cmp);
+	return InterlockedCompareExchangePointer((void* volatile*)mem, with, (void*)cmp);
 #endif
 }
 
@@ -139,7 +139,7 @@ APR_DECLARE(apr_uint32_t) apr_atomic_xchg32(volatile apr_uint32_t *mem, apr_uint
 #elif defined(__MINGW32__)
     return InterlockedExchange((long *)mem, val);
 #else
-    return ((apr_atomic_win32_ptr_val_fn)InterlockedExchange)(mem, val);
+	return InterlockedExchange(mem, val);
 #endif
 }
 
@@ -149,6 +149,6 @@ APR_DECLARE(void*) apr_atomic_xchgptr(volatile void **mem, void *with)
     return InterlockedExchangePointer((void**)mem, with);
 #else
     /* Too many VC6 users have stale win32 API files, stub this */
-    return ((apr_atomic_win32_ptr_ptr_fn)InterlockedExchange)(mem, with);
+	return InterlockedExchangePointer((void**)mem, with);
 #endif
 }


### PR DESCRIPTION
apr_atomic.obj : error LNK2019: unresolved external symbol __InterlockedIncrement referenced in function _apr_atomic_inc32@4
apr_atomic.obj : error LNK2019: unresolved external symbol __InterlockedExchangeAdd referenced in function _apr_atomic_add32@8
apr_atomic.obj : error LNK2019: unresolved external symbol __InterlockedExchange referenced in function _apr_atomic_set32@8
apr_atomic.obj : error LNK2019: unresolved external symbol __InterlockedDecrement referenced in function _apr_atomic_dec32@4
apr_atomic.obj : error LNK2019: unresolved external symbol __InterlockedCompareExchange referenced in function _apr_atomic_cas32@12

这是一个兼容问题：网上找到如下描述
https://groups.google.com/forum/#!topic/UniMRCP/Iybpn51UYnI

注意：
修改后的版本vc6可能不能编译通过。
