### PR TITLE
fixed: ServerApp::onAppActiveTick[049DC6C8]: messagelog:1129652375332851...

### DIFF
--- a/kbe/src/lib/server/componentbridge.cpp
+++ b/kbe/src/lib/server/componentbridge.cpp
@@ -238,6 +238,11 @@ RESTART_RECV:
 							//dispatcher().breakProcessing();
 							return false;
 						}
+						else
+						{
+							findIdx_++;
+							continue;
+						}
 					}
 				}
 				


### PR DESCRIPTION
...700 not found

https://github.com/kbengine/kbengine/issues/91
