### PR TITLE
完善了bundle_broadcast.cpp里提示信息，第二次修改

### DIFF
--- a/kbe/src/lib/network/bundle_broadcast.cpp
+++ b/kbe/src/lib/network/bundle_broadcast.cpp
@@ -159,7 +159,7 @@ bool BundleBroadcast::receive(MessageArgs* recvArgs, sockaddr_in* psin, int32 ti
 			{
 				if(showerr)
 				{
-					ERROR_MSG("BundleBroadcast::receive: is failed(please check {firewall rule => broadcastaddr not is LAN ?})!\n");
+					ERROR_MSG("BundleBroadcast::receive: is failed(please check{firewall rule => broadcastaddr not is LAN ?} and Machine process has been running?)!\n");
 				}
 				
 				return false;


### PR DESCRIPTION
完善了bundle_broadcast.cpp里提示信息，当用户只打开一个服务器进程的时候，原来的提示信息提示是请用户检查防火墙的设置，这是一种情况，还有一种情况是用户初学，只是打开了一个服务端进程，我们需要提醒用户至少还需要再打开Machine进程。

这个是在原来的第二次合并请求修改，再第一次合并请求的指导下修改的。

原因见https://github.com/kbengine/kbengine/pull/237所属的理由。

在bundle_broadcast.cpp文件162行修改的内容为：

ERROR_MSG("BundleBroadcast::receive: is failed(please check{firewall rule => broadcastaddr not is LAN ?} and Machine process has been running?)!\n");

请kbe 哥忽略第一次的请求，可以直接合并这个请求。
				