### PR TITLE
fix error: logical not is only applied to the left hand side of compa…

### DIFF
--- a/kbe/src/lib/dependencies/jwsmtp/jwsmtp/jwsmtp/mailer.cpp
+++ b/kbe/src/lib/dependencies/jwsmtp/jwsmtp/jwsmtp/mailer.cpp
@@ -1207,7 +1207,7 @@ mailer::Address mailer::parseaddress(const std::string& addresstoparse) {
    if(!addresstoparse.length())
       return newaddress; // its empty, oops (this should fail at the server.)
 
-   if(!addresstoparse.find("@") == std::string::npos) {
+   if(!(addresstoparse.find("@") == std::string::npos)) {
       // no '@' symbol (could be a local address, e.g. root)
       // so just assume this. The SMTP server should just deny delivery if its messed up!
       newaddress.address = addresstoparse;


### PR DESCRIPTION
change code for g++ 5.2.1, logical not is only applied to the left hand side of comparison.

mailer.cpp: In member function ‘jwsmtp::mailer::Address jwsmtp::mailer::parseaddress(const string&)’:
mailer.cpp:1210:33: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
    if(!addresstoparse.find("@") == std::string::npos) {
                                 ^
cc1plus: all warnings being treated as errors
/home/boatkrap/src/kbengine/kbe/src/build/common.mak:543: recipe for target 'Hybrid64/mailer.o' failed
make[2]: *** [Hybrid64/mailer.o] Error 1
make[2]: Leaving directory '/home/boatkrap/src/kbengine/kbe/src/lib/dependencies/jwsmtp/jwsmtp/jwsmtp'
Makefile:22: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/boatkrap/src/kbengine/kbe/src/lib'
Makefile:7: recipe for target 'all' failed
make: *** [all] Error 2