### PR TITLE
Add flake8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
       - python3-pip
 before_install:
    - sudo apt-get update
-   - python3 --version ; pip3 --version ; pip3 install --upgrade pip
-   - pip3 install flake8
+   - python3 --version ; pip3 --version ; pip3 install --upgrade --user pip ; pip3 --version
+   - pip3 install --user flake8
 before_script:
    # stop the build if there are Python syntax errors or undefined names
    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ branches:
 #  - stable
 before_install:
    - sudo apt-get update
-   - python -m ensurepip --upgrade --user
    - pip install flake8
 before_script:
    # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@ branches:
   - master
   - 1.x
 #  - stable
+addons:
+  apt:
+    packages:
+      - python3-pip
 before_install:
    - sudo apt-get update
-   - pip install --user flake8
+   - pip3 install --user flake8
 before_script:
    # stop the build if there are Python syntax errors or undefined names
    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
       - python3-pip
 before_install:
    - sudo apt-get update
-   - python3 --version ; pip3 --version ; pip3 install --upgrade --user pip ; pip3 --version
-   - pip3 install --user flake8
+   - python3 --version ; pip3 --version ; sudo pip3 install --upgrade pip ; pip3 --version
+   - sudo pip3 install flake8
 before_script:
    # stop the build if there are Python syntax errors or undefined names
    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ branches:
 #  - stable
 before_install:
    - sudo apt-get update
+   - python -m ensurepip --upgrade --user
+   - pip install flake8
+before_script:
+   # stop the build if there are Python syntax errors or undefined names
+   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 notifications:
   recipients:
     - kbesrv@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ addons:
       - python3-pip
 before_install:
    - sudo apt-get update
-   - pip3 install --user flake8
+   - python3 --version ; pip3 --version ; pip3 install --upgrade pip
+   - pip3 install flake8
 before_script:
    # stop the build if there are Python syntax errors or undefined names
    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 #  - stable
 before_install:
    - sudo apt-get update
-   - pip install flake8
+   - pip install --user flake8
 before_script:
    # stop the build if there are Python syntax errors or undefined names
    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ before_install:
    - python3 --version ; pip3 --version ; sudo pip3 install --upgrade pip ; pip3 --version
    - sudo pip3 install flake8
 before_script:
+   - EXCLUDE=kbe/src/lib/python,kbe/res/scripts/common/Lib,kbe/src/lib/dependencies/jemalloc/scripts,kbe/tools/server/webconsole/six.py
    # stop the build if there are Python syntax errors or undefined names
-   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude=$EXCLUDE
    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=$EXCLUDE
 notifications:
   recipients:
     - kbesrv@gmail.com


### PR DESCRIPTION
http://flake8.pycqa.org  E901,E999,F821,F822,F823 are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. The other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.

Flake8 testing on __Python 3__:
```
19    E999 SyntaxError: invalid syntax
823   F821 undefined name 'macro_lines'
20    F822 undefined name 'FMT_BINARY' in __all__
2     F823 local variable '__loader__' (defined in enclosing scope on line 338) referenced before assignment
864
```
Flake8 testing on __Python 2__:
```
523   E999 SyntaxError: invalid syntax
842   F821 undefined name 'BlockingIOError'
16    F822 undefined name 'set_extraction_path' in __all__
1381
```