### PR TITLE
Fix missing imports and bare exceptions

### DIFF
--- a/kbe/tools/server/install/installer.py
+++ b/kbe/tools/server/install/installer.py
@@ -29,7 +29,12 @@ else:
 	
 	if platform.system() == 'Windows':
 		import _winreg as winreg
-            
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 # Sources and binary releases
 source_url = "https://github.com/kbengine/kbengine/releases/latest"
 bin_zip_url = "https://sourceforge.net/projects/kbengine/files/bin/latest.zip/download"
@@ -151,9 +156,6 @@ def WARING_MSG(msg):
 	print('WARING: ' + msg)
 
 def getInput(s):
-	if sys.hexversion >= 0x03000000:
-		return input(s)
-	
 	return raw_input(s)
 	
 def echoKBEEnvironment():

--- a/kbe/tools/server/pycommon/Machines.py
+++ b/kbe/tools/server/pycommon/Machines.py
@@ -105,7 +105,7 @@ class Machines:
 			try:
 				if type(self.username) is unicode:
 					self.username = username.encode( "utf-8" )
-			except:
+			except NameError:
 				pass
 		
 		self.startListen()
@@ -371,4 +371,3 @@ class Machines:
 		获取某一类型的组件信息
 		"""
 		return self.interfaces.get( componentType, [] )
-

--- a/kbe/tools/server/pycommon/MessageStream.py
+++ b/kbe/tools/server/pycommon/MessageStream.py
@@ -12,11 +12,11 @@ try:
 	bytes
 	try:
 		unicode
-	except:
+	except NameError:
 		unicode = str
 	NULL_TERMINATOR = "\0".encode()
 	NULL_BYTES = "".encode()
-except:
+except NameError:
 	bytes = str
 	NULL_TERMINATOR = "\0"
 	NULL_BYTES = ""

--- a/kbe/tools/server/webconsole/WebConsole/views_log.py
+++ b/kbe/tools/server/webconsole/WebConsole/views_log.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.core.exceptions import ObjectDoesNotExist


### PR DESCRIPTION
Fixes the following issues

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./kbe/tools/server/pycommon/MessageStream.py:14:3: F821 undefined name 'unicode'
		unicode
  ^
./kbe/tools/server/pycommon/Machines.py:106:31: F821 undefined name 'unicode'
				if type(self.username) is unicode:
                              ^
./kbe/tools/server/install/installer.py:157:9: F821 undefined name 'raw_input'
	return raw_input(s)
        ^
./kbe/tools/server/webconsole/WebConsole/views_log.py:215:23: F821 undefined name 'json'
		return HttpResponse(json.dumps(message))
                      ^
./kbe/tools/server/webconsole/WebConsole/views_log.py:362:23: F821 undefined name 'json'
	return HttpResponse( json.dumps( message ) ,content_type='application/json' )
                      ^
```