### PR TITLE
unity sdk的vector2、vector3、vector4的构造中不调用read形式的函数

### DIFF
--- a/kbe/res/client/sdk_templates/unity/KBEngine.cs
+++ b/kbe/res/client/sdk_templates/unity/KBEngine.cs
@@ -433,7 +433,7 @@
 				if (serverEntitydefMD5 != currentServerEntitydefMD5)
 				{
 					Dbg.ERROR_MSG("Client_onHelloCB: digest not match! serverEntitydefMD5=" + serverEntitydefMD5 + "(server: " + currentServerEntitydefMD5 + ")");
-					Event.fireAll(EventOutTypes.onVersionNotMatch", clientVersion, serverVersion);
+					Event.fireAll(EventOutTypes.onVersionNotMatch, clientVersion, serverVersion);
 					return;
 				}
 			}

--- a/kbe/res/client/sdk_templates/unity/MemoryStream.cs
+++ b/kbe/res/client/sdk_templates/unity/MemoryStream.cs
@@ -170,17 +170,26 @@
 
 		public Vector2 readVector2()
 		{
-			return new Vector2(readFloat(), readFloat());
+			float x = readFloat();
+			float y = readFloat();
+			return new Vector2(x, y);
 		}
 
 		public Vector3 readVector3()
 		{
-			return new Vector3(readFloat(), readFloat(), readFloat());
+			float x = readFloat();
+			float y = readFloat();
+			float z = readFloat();
+			return new Vector3(x, y, z);
 		}
 
 		public Vector4 readVector4()
 		{
-			return new Vector4(readFloat(), readFloat(), readFloat(), readFloat());
+			float x = readFloat();
+			float y = readFloat();
+			float z = readFloat();
+			float w = readFloat();
+			return new Vector4(x, y, z, w);
 		}
 
 		public byte[] readPython()


### PR DESCRIPTION
unity sdk的vector2、vector3、vector4的构造中不调用read形式的函数