### PR TITLE
ue4 sdk事件漏补:将所有的事件名称放到一个类作为常量，中提供编辑器提示作用

### DIFF
--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/Entity.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/Entity.cpp
@@ -81,7 +81,7 @@ void Entity::leaveWorld()
 	pEventData->entityID = id();
 	pEventData->spaceID = KBEngineApp::getSingleton().spaceID();
 	pEventData->isPlayer = isPlayer();
-	KBENGINE_EVENT_FIRE("onLeaveWorld", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onLeaveWorld, pEventData);
 }
 
 void Entity::onLeaveWorld()

--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/KBEngine.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/KBEngine.cpp
@@ -499,7 +499,7 @@ void KBEngineApp::Client_onHelloCB(MemoryStream& stream)
 			UKBEventData_onVersionNotMatch* pEventData = NewObject<UKBEventData_onVersionNotMatch>();
 			pEventData->clientVersion = clientVersion_;
 			pEventData->serverVersion = serverVersion_;
-			KBENGINE_EVENT_FIRE("onVersionNotMatch", pEventData);
+			KBENGINE_EVENT_FIRE(KBEventTypes::onVersionNotMatch, pEventData);
 			return;
 		}
 		*/
@@ -543,7 +543,7 @@ void KBEngineApp::Client_onVersionNotMatch(MemoryStream& stream)
 	UKBEventData_onVersionNotMatch* pEventData = NewObject<UKBEventData_onVersionNotMatch>();
 	pEventData->clientVersion = clientVersion_;
 	pEventData->serverVersion = serverVersion_;
-	KBENGINE_EVENT_FIRE("onVersionNotMatch", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onVersionNotMatch, pEventData);
 }
 
 void KBEngineApp::Client_onScriptVersionNotMatch(MemoryStream& stream)
@@ -555,7 +555,7 @@ void KBEngineApp::Client_onScriptVersionNotMatch(MemoryStream& stream)
 	UKBEventData_onScriptVersionNotMatch* pEventData = NewObject<UKBEventData_onScriptVersionNotMatch>();
 	pEventData->clientScriptVersion = clientScriptVersion_;
 	pEventData->serverScriptVersion = serverScriptVersion_;
-	KBENGINE_EVENT_FIRE("onScriptVersionNotMatch", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onScriptVersionNotMatch, pEventData);
 }
 
 void KBEngineApp::Client_onKicked(uint16 failedcode)
@@ -1052,7 +1052,7 @@ void KBEngineApp::Client_setSpaceData(uint32 spaceID, const FString& key, const 
 	pEventData->spaceID = spaceID_;
 	pEventData->key = key;
 	pEventData->value = value;
-	KBENGINE_EVENT_FIRE("onSetSpaceData", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onSetSpaceData, pEventData);
 }
 
 void KBEngineApp::Client_delSpaceData(uint32 spaceID, const FString& key)

--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/NetworkInterfaceBase.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/NetworkInterfaceBase.cpp
@@ -39,7 +39,7 @@ void NetworkInterfaceBase::close()
 		socket_->Close();
 		INFO_MSG("NetworkInterfaceBase::close(): network closed!");
 		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(socket_);
-		KBENGINE_EVENT_FIRE("onDisconnected", NewObject<UKBEventData_onDisconnected>());
+		KBENGINE_EVENT_FIRE(KBEventTypes::onDisconnected, NewObject<UKBEventData_onDisconnected>());
 	}
 
 	socket_ = NULL;
@@ -182,7 +182,7 @@ void NetworkInterfaceBase::tickConnecting()
 		UKBEventData_onConnectionState* pEventData = NewObject<UKBEventData_onConnectionState>();
 		pEventData->success = true;
 		pEventData->address = FString::Printf(TEXT("%s:%d"), *connectIP_, connectPort_);
-		KBENGINE_EVENT_FIRE("onConnectionState", pEventData);
+		KBENGINE_EVENT_FIRE(KBEventTypes::onConnectionState, pEventData);
 	}
 	else
 	{
@@ -197,7 +197,7 @@ void NetworkInterfaceBase::tickConnecting()
 			UKBEventData_onConnectionState* pEventData = NewObject<UKBEventData_onConnectionState>();
 			pEventData->success = false;
 			pEventData->address = FString::Printf(TEXT("%s:%d"), *connectIP_, connectPort_);
-			KBENGINE_EVENT_FIRE("onConnectionState", pEventData);
+			KBENGINE_EVENT_FIRE(KBEventTypes::onConnectionState, pEventData);
 		}
 	}
 }

--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/NetworkInterfaceKCP.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/NetworkInterfaceKCP.cpp
@@ -161,7 +161,7 @@ void NetworkInterfaceKCP::tickConnecting()
 			UKBEventData_onConnectionState* pEventData = NewObject<UKBEventData_onConnectionState>();
 			pEventData->success = success;
 			pEventData->address = FString::Printf(TEXT("%s:%d"), *connectIP_, connectPort_);
-			KBENGINE_EVENT_FIRE("onConnectionState", pEventData);
+			KBENGINE_EVENT_FIRE(KBEventTypes::onConnectionState, pEventData);
 		}
 	}
 	else
@@ -176,7 +176,7 @@ void NetworkInterfaceKCP::tickConnecting()
 			UKBEventData_onConnectionState* pEventData = NewObject<UKBEventData_onConnectionState>();
 			pEventData->success = false;
 			pEventData->address = FString::Printf(TEXT("%s:%d"), *connectIP_, connectPort_);
-			KBENGINE_EVENT_FIRE("onConnectionState", pEventData);
+			KBENGINE_EVENT_FIRE(KBEventTypes::onConnectionState, pEventData);
 		}
 	}
 }


### PR DESCRIPTION
ue4 sdk事件漏补:将所有的事件名称放到一个类作为常量，中提供编辑器提示作用