### PR TITLE
ue4 sdk事件漏补:将所有的事件名称放到一个类作为常量，中提供编辑器提示作用

### DIFF
--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/Entity.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/Entity.cpp
@@ -81,7 +81,7 @@ void Entity::leaveWorld()
 	pEventData->entityID = id();
 	pEventData->spaceID = KBEngineApp::getSingleton().spaceID();
 	pEventData->isPlayer = isPlayer();
-	KBENGINE_EVENT_FIRE("onLeaveWorld", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onLeaveWorld, pEventData);
 }
 
 void Entity::onLeaveWorld()

--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/KBEngine.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/KBEngine.cpp
@@ -486,7 +486,7 @@ void KBEngineApp::Client_onHelloCB(MemoryStream& stream)
 			UKBEventData_onVersionNotMatch* pEventData = NewObject<UKBEventData_onVersionNotMatch>();
 			pEventData->clientVersion = clientVersion_;
 			pEventData->serverVersion = serverVersion_;
-			KBENGINE_EVENT_FIRE("onVersionNotMatch", pEventData);
+			KBENGINE_EVENT_FIRE(KBEventTypes::onVersionNotMatch, pEventData);
 			return;
 		}
 		*/
@@ -530,7 +530,7 @@ void KBEngineApp::Client_onVersionNotMatch(MemoryStream& stream)
 	UKBEventData_onVersionNotMatch* pEventData = NewObject<UKBEventData_onVersionNotMatch>();
 	pEventData->clientVersion = clientVersion_;
 	pEventData->serverVersion = serverVersion_;
-	KBENGINE_EVENT_FIRE("onVersionNotMatch", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onVersionNotMatch, pEventData);
 }
 
 void KBEngineApp::Client_onScriptVersionNotMatch(MemoryStream& stream)
@@ -542,7 +542,7 @@ void KBEngineApp::Client_onScriptVersionNotMatch(MemoryStream& stream)
 	UKBEventData_onScriptVersionNotMatch* pEventData = NewObject<UKBEventData_onScriptVersionNotMatch>();
 	pEventData->clientScriptVersion = clientScriptVersion_;
 	pEventData->serverScriptVersion = serverScriptVersion_;
-	KBENGINE_EVENT_FIRE("onScriptVersionNotMatch", pEventData);
+	KBENGINE_EVENT_FIRE(KBEventTypes::onScriptVersionNotMatch, pEventData);
 }
 
 void KBEngineApp::Client_onKicked(uint16 failedcode)

--- a/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/NetworkInterface.cpp
+++ b/kbe/res/sdk_templates/client/ue4/Source/KBEnginePlugins/Engine/NetworkInterface.cpp
@@ -38,7 +38,7 @@ void NetworkInterface::close()
 		socket_->Close();
 		INFO_MSG("NetworkInterface::close(): network closed!");
 		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(socket_);
-		KBENGINE_EVENT_FIRE("onDisconnected", NewObject<UKBEventData_onDisconnected>());
+		KBENGINE_EVENT_FIRE(KBEventTypes::onDisconnected, NewObject<UKBEventData_onDisconnected>());
 	}
 
 	socket_ = NULL;
@@ -170,7 +170,7 @@ void NetworkInterface::tickConnecting()
 		UKBEventData_onConnectionState* pEventData = NewObject<UKBEventData_onConnectionState>();
 		pEventData->success = true;
 		pEventData->address = FString::Printf(TEXT("%s:%d"), *connectIP_, connectPort_);
-		KBENGINE_EVENT_FIRE("onConnectionState", pEventData);
+		KBENGINE_EVENT_FIRE(KBEventTypes::onConnectionState, pEventData);
 	}
 	else
 	{
@@ -185,7 +185,7 @@ void NetworkInterface::tickConnecting()
 			UKBEventData_onConnectionState* pEventData = NewObject<UKBEventData_onConnectionState>();
 			pEventData->success = false;
 			pEventData->address = FString::Printf(TEXT("%s:%d"), *connectIP_, connectPort_);
-			KBENGINE_EVENT_FIRE("onConnectionState", pEventData);
+			KBENGINE_EVENT_FIRE(KBEventTypes::onConnectionState, pEventData);
 		}
 	}
 }


### PR DESCRIPTION
ue4 sdk事件漏补:将所有的事件名称放到一个类作为常量，中提供编辑器提示作用