### PR TITLE
相同服务器版本在linux下和windows下协议的MD5计算结果不一致问题

### DIFF
--- a/kbe/src/lib/network/message_handler.cpp
+++ b/kbe/src/lib/network/message_handler.cpp
@@ -333,9 +333,6 @@ std::string MessageHandlers::getDigestStr()
 				int32 argsize = pMessageHandler->pArgs->strArgsTypes.size();
 				md5.append((void*)&argsize, sizeof(int32));
 
-				int32 argsdataSize = pMessageHandler->pArgs->dataSize();
-				md5.append((void*)&argsdataSize, sizeof(int32));
-
 				int32 argstype = (int32)pMessageHandler->pArgs->type();
 				md5.append((void*)&argstype, sizeof(int32));
 


### PR DESCRIPTION
相同服务器版本在linux下和windows下协议的MD5计算结果不一致问题