### PR TITLE
dataType中PYTHON、PY_DICT、PY_TUPLE、PY_LIST在def中默认值支持

### DIFF
--- a/kbe/src/lib/entitydef/datatype.cpp
+++ b/kbe/src/lib/entitydef/datatype.cpp
@@ -1196,8 +1196,16 @@ PyObject* PythonType::parseDefaultStr(std::string defaultVal)
 
 		PyObject* mdict = PyModule_GetDict(module); // Borrowed reference.
 		
-		return PyRun_String(const_cast<char*>(defaultVal.c_str()), 
+		PyObject* result = PyRun_String(const_cast<char*>(defaultVal.c_str()), 
 							Py_eval_input, mdict, mdict);
+
+		if (result == NULL)
+		{
+			SCRIPT_ERROR_CHECK();
+			S_Return;
+		}
+
+		return result;
 	}
 		
 	S_Return;


### PR DESCRIPTION
dataType中PYTHON、PY_DICT、PY_TUPLE、PY_LIST在def中默认值支持