### PR TITLE
streamStringToClient等接口， 同一个tick中多次使用同一个id下载资源时id不是预期的也没有警告 #996

### DIFF
--- a/kbe/src/server/baseapp/proxy.cpp
+++ b/kbe/src/server/baseapp/proxy.cpp
@@ -731,6 +731,11 @@ PyObject* Proxy::__py_pyStreamStringToClient(PyObject* self, PyObject* args)
 						(pDescr == NULL ? "" : pDescr),  
 						id);
 
+	if (rid != id)
+	{
+		WARNING_MSG(fmt::format("Proxy::streamFileToClient: the id({}) has been used, a new id({}) is assigned!\n", id, rid));
+	}
+
 	return PyLong_FromLong(rid);
 }
 


### PR DESCRIPTION
https://github.com/kbengine/kbengine/issues/996