### PR TITLE
fix create singleton instance ServerConfig twice

### DIFF
--- a/kbe/src/lib/client_lib/config.cpp
+++ b/kbe/src/lib/client_lib/config.cpp
@@ -12,8 +12,6 @@
 namespace KBEngine{
 KBE_SINGLETON_INIT(Config);
 
-ServerConfig g_ServerConfig;
-
 //-------------------------------------------------------------------------------------
 Config::Config():
 gameUpdateHertz_(10),


### PR DESCRIPTION
The singleton ServerConfig has been created twice, one in config.cpp, another in baseapp/kbcmd/etc. when running baseapp/kbcmd/etc. in debug mode, assert in singleton.h:32 will rase an assertion.